### PR TITLE
Add index.html to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,1 @@
-
+index.html


### PR DESCRIPTION
This should make it less likely that we'll accidentally check in a copy of the spec that will grow stale over time.