### PR TITLE
spec: Start Controlled Frame IDL

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -104,3 +104,100 @@ edit elements in embedded content through arbitrary script injection into the
 web content can ensure navigation cannot occur to blocked pages. The embedder
 can also use the Controlled Frame API to capture navigation events and ensure
 that only pages to approved sites can be loaded within that controlled frame.
+
+# Controlled Frame API # {#controlled-frame-api}
+
+<xmp class="idl">
+enum ContextType {
+    "all",
+    "page",
+    "frame",
+    "selection",
+    "link",
+    "editable",
+    "image",
+    "video",
+    "audio",
+};
+
+enum ItemType {
+    "normal",
+    "checkbox",
+    "radio",
+    "separator",
+};
+
+dictionary OnClickData {
+    boolean checked;
+    required boolean editable;
+    long frameId;
+    USVString frameUrl;
+    USVString linkUrl;
+    DOMString mediaType;
+    required (DOMString or long) menuItemId;
+    USVString pageUrl;
+    (DOMString or long) parentMenuId;
+    DOMString selectionText;
+    USVString srcUrl;
+    boolean wasChecked;
+};
+
+callback ContextMenusEventListener = undefined (OnClickData data);
+
+dictionary ContextMenusProperties {
+    boolean checked;
+    sequence<ContextType> context;
+    DOMString documentUrlPatterns;
+    boolean enabled;
+    DOMString parentId;
+    DOMString targetUrlPatterns;
+    DOMString title;
+    ItemType type;
+    ContextMenusEventListener onclick;
+};
+
+dictionary ContextMenusCreateProperties : ContextMenusProperties {
+    DOMString id;
+};
+
+callback ContextMenusCallback = undefined ();
+
+[Exposed=Window, SecureContext]
+interface ContextMenus {
+    // TODO: Define the `onShow` property.
+
+    // Returns the ID of the newly created menu item.
+    (DOMString or long) create(
+        ContextMenusCreateProperties properties,
+        ContextMenusCallback? callback);
+
+    undefined remove(
+        (DOMString or long) menuItemId,
+        ContextMenusCallback? callback);
+    undefined removeAll(ContextMenusCallback? callback);
+    undefined update(
+        (DOMString or long) id,
+        ContextMenusProperties properties,
+        ContextMenusCallback? callback);
+};
+
+[Exposed=Window, SecureContext]
+interface ControlledFrame : HTMLElement {
+    [HTMLConstructor] constructor();
+ 
+    [CEReactions] attribute USVString src;
+    [CEReactions] attribute DOMString name;
+    [CEReactions] attribute boolean allowfullscreen;
+    [CEReactions] attribute boolean allowscaling;
+    [CEReactions] attribute boolean allowtransparency;
+    [CEReactions] attribute boolean autosize;
+    [CEReactions] attribute DOMString maxheight;
+    [CEReactions] attribute DOMString maxwidth;
+    [CEReactions] attribute DOMString minheight;
+    [CEReactions] attribute DOMString minwidth;
+    attribute DOMString partition;
+
+    readonly attribute WindowProxy? contentWindow;
+    readonly attribute ContextMenus contextMenus;
+};
+</xmp>


### PR DESCRIPTION
This commit starts the IDL definition for the Controlled Frame API. It defines the attributes of <controlledframe> except for the `request` property. It also omits the ContextMenus.onShow property, since it differs from a standard Event, so it would require more thought into how it should be defined. It doesn't have an addEventListener() or other EventTarget interface methods; instead it defines its own addListener() method.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/odejesush/controlled-frame/pull/20.html" title="Last updated on May 19, 2023, 9:33 PM UTC (d499f87)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/chasephillips/controlled-frame/20/8305919...odejesush:d499f87.html" title="Last updated on May 19, 2023, 9:33 PM UTC (d499f87)">Diff</a>