### PR TITLE
test app: Fix contextMenus.create paramter parsing

### DIFF
--- a/test_app/controlledframe_api.js
+++ b/test_app/controlledframe_api.js
@@ -987,6 +987,12 @@ class ControlledFrameController {
       e.preventDefault();
   }
 
+  #setIfValid(object, keyName, keyValue) {
+    if (keyValue && keyValue.length > 0) {
+      object[keyName] = keyValue;
+    }
+  }
+
   #readContextMenusCreateProperties() {
     let contexts = new Array();
     for (const option of $('#context_menus_create_properties_contexts_in')
@@ -1004,21 +1010,10 @@ class ControlledFrameController {
       },
     };
 
-    let id = $('#context_menus_create_properties_id_in').value;
-    if (id.length > 0) {
-      createProperties.id = id;
-    }
-    let parentId = $('#context_menus_create_properties_parent_id_in').value;
-    if (parentId.length > 0) {
-      createProperties.parentId = parentId;
-    }
-    let title = $('#context_menus_create_properties_title_in').value;
-    if (title.length > 0) {
-      createProperties.title = title;
-    }
-    let type = $('#context_menus_create_properties_type_in').value;
-    if (type.length > 0) {
-      createProperties.type = type;
+    for (const keyName of ['id', 'parentId', 'title', 'type']) {
+      const keyValue =
+        $(`#context_menus_create_properties_${keyName}_in`).value;
+      this.#setIfValid(createProperties, keyName, keyValue);
     }
 
     let documentUrlPatternsValue = $(

--- a/test_app/controlledframe_api.js
+++ b/test_app/controlledframe_api.js
@@ -996,18 +996,30 @@ class ControlledFrameController {
 
     let createProperties = {
       checked: $('#context_menus_create_properties_checked_chk').checked,
-      contexts: contexts,
       enabled: $('#context_menus_create_properties_enabled_chk').checked,
-      id: $('#context_menus_create_properties_id_in').value,
-      parentId: $('#context_menus_create_properties_parent_id_in').value,
-      title: $('#context_menus_create_properties_title_in').value,
-      type: $('#context_menus_create_properties_type_in').value,
       onclick: info => {
         let infoJSON = JSON.stringify(info);
         Log.info(`context menu item clicked: ${infoJSON}`);
         $('#context_menus_on_click_result').innerText = infoJSON;
       },
     };
+
+    let id = $('#context_menus_create_properties_id_in').value;
+    if (id.length > 0) {
+      createProperties.id = id;
+    }
+    let parentId = $('#context_menus_create_properties_parent_id_in').value;
+    if (parentId.length > 0) {
+      createProperties.parentId = parentId;
+    }
+    let title = $('#context_menus_create_properties_title_in').value;
+    if (title.length > 0) {
+      createProperties.title = title;
+    }
+    let type = $('#context_menus_create_properties_type_in').value;
+    if (type.length > 0) {
+      createProperties.type = type;
+    }
 
     let documentUrlPatternsValue = $(
       '#context_menus_create_properties_document_url_patterns_in'

--- a/test_app/index.html
+++ b/test_app/index.html
@@ -117,8 +117,8 @@
             <label for="context_menus_create_properties_id_in">id</label>
             <input type="text" id="context_menus_create_properties_id_in" />
 
-            <label for="context_menus_create_properties_parent_id_in">parentId</label>
-            <input type="text" id="context_menus_create_properties_parent_id_in" />
+            <label for="context_menus_create_properties_parentId_in">parentId</label>
+            <input type="text" id="context_menus_create_properties_parentId_in" />
 
             <label for="context_menus_create_properties_target_url_patterns_in">targetUrlPatterns</label>
             <input type="text" id="context_menus_create_properties_target_url_patterns_in" />


### PR DESCRIPTION
This commit fixes the parsing for the contextMenus.create and contextMenus.update parameters. The fix is to prevent the fields in the parameter object from being set when the input fields don't have a value. The internal API implementation does not consider an empty string field to be the same as undefined, so this caused the API to not work properly in the test app.