### PR TITLE
Fix IWA install by adding version to manifest

### DIFF
--- a/test_app/manifest.webmanifest
+++ b/test_app/manifest.webmanifest
@@ -13,5 +13,6 @@
   "display": "fullscreen",
   "theme_color": "white",
   "background_color": "white",
-  "isolated_storage": true
+  "isolated_storage": true,
+  "version": "1.0.0"
 }


### PR DESCRIPTION
This commit fixes the IWA installation on recent source code builds of Chrome due to the manifest missing the "version" field.