### PR TITLE
Add the cross-origin-isolated policy

### DIFF
--- a/test_app/manifest.webmanifest
+++ b/test_app/manifest.webmanifest
@@ -14,5 +14,10 @@
   "theme_color": "white",
   "background_color": "white",
   "isolated_storage": true,
-  "version": "1.0.0"
+  "version": "1.0.0",
+  "permissions_policy": {
+    "cross-origin-isolated": [
+      "self"
+    ]
+  }
 }


### PR DESCRIPTION
This commit adds the cross-origin-isolated permission policy field to the manifest. Without this field, Controlled Frame no longer works.